### PR TITLE
feat: automatic token refresh on 401

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,4 +1,4 @@
-import { TwentyApiClient, extractTokenFromCookie } from '../lib/twenty-api';
+import { TwentyApiClient, extractTokenFromCookie, extractRefreshTokenFromCookie } from '../lib/twenty-api';
 import { getSettings, saveSettings, addToRecentCaptures, getRecentCaptures } from '../lib/storage';
 import { track } from '../lib/analytics';
 import { getNormalizedDomain } from '../lib/domain-extractor';
@@ -7,7 +7,7 @@ import type { ExtensionMessage, ExtensionResponse, LinkedInProfileData, LinkedIn
 // Cache for API client
 let apiClient: TwentyApiClient | null = null;
 let cachedTwentyUrl: string | null = null;
-let cachedAuthToken: { apiBaseUrl: string; token: string; checkedAt: number } | null = null;
+let cachedAuthToken: { apiBaseUrl: string; token: string; refreshToken: string | null; checkedAt: number } | null = null;
 
 const AUTH_TOKEN_CACHE_TTL_MS = 5 * 60 * 1000;
 
@@ -153,12 +153,21 @@ async function getApiClient(): Promise<TwentyApiClient> {
   }
 
   // Get fresh token from cookie
-  const token = await getAuthToken(settings.twentyUrl);
-  if (!token) {
+  const authResult = await getAuthToken(settings.twentyUrl);
+  if (!authResult) {
     throw new Error('No authentication token found. Please log in to Twenty CRM.');
   }
 
-  apiClient.setToken(token);
+  apiClient.setToken(authResult.token);
+  if (authResult.refreshToken) {
+    apiClient.setRefreshToken(authResult.refreshToken);
+    apiClient.setOnTokenRefreshed((newToken) => {
+      // Update the cache so subsequent calls use the refreshed token
+      if (cachedAuthToken) {
+        cachedAuthToken = { ...cachedAuthToken, token: newToken, checkedAt: Date.now() };
+      }
+    });
+  }
   return apiClient;
 }
 
@@ -190,12 +199,13 @@ function getTwentyCookieUrls(twentyUrl: string): string[] {
 }
 
 // Get auth token from Twenty's cookie
-async function getAuthToken(twentyUrl: string): Promise<string | null> {
+async function getAuthToken(twentyUrl: string): Promise<{ token: string; refreshToken: string | null } | null> {
   try {
     const apiBaseUrl = resolveTwentyApiBaseUrl(twentyUrl);
     const cookieUrls = getTwentyCookieUrls(twentyUrl);
     const cookieNames = ['tokenPair', 'accessToken', 'access-token'];
     const tokenCandidates: string[] = [];
+    let refreshToken: string | null = null;
     let checkedPermittedHost = false;
 
     for (const url of cookieUrls) {
@@ -223,10 +233,17 @@ async function getAuthToken(twentyUrl: string): Promise<string | null> {
             tokenCandidates.push(token);
           }
           console.log('Successfully extracted token candidate from cookie', cookieName, 'for', url);
-          continue;
+        } else {
+          console.warn('Cookie found but token extraction failed for', url, cookieName);
         }
 
-        console.warn('Cookie found but token extraction failed for', url, cookieName);
+        // Extract refresh token if we don't have one yet
+        if (!refreshToken) {
+          refreshToken = extractRefreshTokenFromCookie(cookie.value);
+          if (refreshToken) {
+            console.log('Extracted refresh token from cookie', cookieName, 'for', url);
+          }
+        }
       }
     }
 
@@ -244,7 +261,7 @@ async function getAuthToken(twentyUrl: string): Promise<string | null> {
       && (Date.now() - cachedAuthToken.checkedAt) < AUTH_TOKEN_CACHE_TTL_MS
       && tokenCandidates.includes(cachedAuthToken.token)
     ) {
-      return cachedAuthToken.token;
+      return { token: cachedAuthToken.token, refreshToken: cachedAuthToken.refreshToken };
     }
 
     for (const candidateToken of tokenCandidates) {
@@ -253,15 +270,16 @@ async function getAuthToken(twentyUrl: string): Promise<string | null> {
         cachedAuthToken = {
           apiBaseUrl,
           token: candidateToken,
+          refreshToken,
           checkedAt: Date.now(),
         };
         console.log('Validated auth token candidate for', apiBaseUrl);
-        return candidateToken;
+        return { token: candidateToken, refreshToken };
       }
     }
 
     console.warn('Could not validate token candidates; using first extracted token as fallback.');
-    return tokenCandidates[0];
+    return { token: tokenCandidates[0], refreshToken };
   } catch (error) {
     console.error('Error getting auth token:', error);
     return null;
@@ -495,8 +513,8 @@ async function handleMessage(message: ExtensionMessage): Promise<ExtensionRespon
         if (!settings.twentyUrl) {
           return { success: false, error: 'Twenty URL not configured' };
         }
-        const token = await getAuthToken(settings.twentyUrl);
-        return { success: !!token, data: { hasToken: !!token } };
+        const authResult = await getAuthToken(settings.twentyUrl);
+        return { success: !!authResult, data: { hasToken: !!authResult } };
       }
 
       case 'CHECK_DUPLICATE': {

--- a/lib/twenty-api.ts
+++ b/lib/twenty-api.ts
@@ -239,6 +239,8 @@ function formatGraphQLErrors(
 export class TwentyApiClient {
   private baseUrl: string;
   private token: string | null = null;
+  private refreshToken: string | null = null;
+  private onTokenRefreshed: ((newToken: string) => void) | null = null;
 
   constructor(baseUrl: string) {
     this.baseUrl = baseUrl.replace(/\/$/, '');
@@ -246,6 +248,75 @@ export class TwentyApiClient {
 
   setToken(token: string) {
     this.token = token;
+  }
+
+  setRefreshToken(refreshToken: string) {
+    this.refreshToken = refreshToken;
+  }
+
+  setOnTokenRefreshed(callback: (newToken: string) => void) {
+    this.onTokenRefreshed = callback;
+  }
+
+  async renewToken(): Promise<string | null> {
+    if (!this.refreshToken) {
+      return null;
+    }
+
+    try {
+      const response = await fetch(`${this.baseUrl}/graphql`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          query: `
+            mutation RenewToken($appToken: String!) {
+              renewToken(appToken: $appToken) {
+                tokens {
+                  accessToken { token expiresAt }
+                  refreshToken { token expiresAt }
+                }
+              }
+            }
+          `,
+          variables: { appToken: this.refreshToken },
+        }),
+      });
+
+      if (!response.ok) {
+        console.warn('[Twenty] Token renewal HTTP error:', response.status);
+        return null;
+      }
+
+      const result = await response.json() as {
+        data?: { renewToken?: { tokens?: { accessToken?: { token: string }; refreshToken?: { token: string } } } };
+        errors?: Array<{ message: string }>;
+      };
+
+      if (result.errors?.length) {
+        console.warn('[Twenty] Token renewal GraphQL error:', result.errors[0].message);
+        return null;
+      }
+
+      const newAccessToken = result.data?.renewToken?.tokens?.accessToken?.token;
+      const newRefreshToken = result.data?.renewToken?.tokens?.refreshToken?.token;
+
+      if (!newAccessToken) {
+        console.warn('[Twenty] Token renewal returned no access token');
+        return null;
+      }
+
+      console.log('[Twenty] Token renewed successfully');
+      this.token = newAccessToken;
+      if (newRefreshToken) {
+        this.refreshToken = newRefreshToken;
+      }
+
+      this.onTokenRefreshed?.(newAccessToken);
+      return newAccessToken;
+    } catch (error) {
+      console.error('[Twenty] Error renewing token:', error);
+      return null;
+    }
   }
 
   // Upload an image via GraphQL multipart upload
@@ -366,10 +437,17 @@ export class TwentyApiClient {
     try {
       response = await performRequest(this.token);
 
-      // Some Twenty deployments rely on cookie-based auth; retry without bearer once.
+      // Try token refresh on 401 before falling back to cookie-only.
       if ((response.status === 401 || response.status === 403) && this.token) {
-        console.warn('[Twenty] Bearer auth rejected, retrying request with cookie credentials only.');
-        response = await performRequest(null);
+        const newToken = await this.renewToken();
+        if (newToken) {
+          console.log('[Twenty] Retrying request with refreshed token.');
+          response = await performRequest(newToken);
+        } else {
+          // Some Twenty deployments rely on cookie-based auth; retry without bearer once.
+          console.warn('[Twenty] Bearer auth rejected, retrying request with cookie credentials only.');
+          response = await performRequest(null);
+        }
       }
     } catch (error) {
       // Network error (CORS, DNS, etc.)
@@ -959,6 +1037,32 @@ export class TwentyApiClient {
       return parseInt(match[1].replace(/,/g, ''), 10);
     }
     return undefined;
+  }
+}
+
+// Helper to extract the refresh token from Twenty's tokenPair cookie
+export function extractRefreshTokenFromCookie(cookieValue: string): string | null {
+  try {
+    let normalized = cookieValue.trim();
+    // URL-decode up to 2 times
+    for (let i = 0; i < 2; i++) {
+      try {
+        const decoded = decodeURIComponent(normalized);
+        if (decoded === normalized) break;
+        normalized = decoded;
+      } catch {
+        break;
+      }
+    }
+
+    const tokenPair = JSON.parse(normalized) as TwentyTokenPair;
+    const raw = tokenPair.refreshToken?.token;
+    if (typeof raw !== 'string' || !raw.trim()) return null;
+
+    const value = raw.trim().replace(/^"+|"+$/g, '');
+    return value.startsWith('Bearer ') ? value.slice(7).trim() : value;
+  } catch {
+    return null;
   }
 }
 


### PR DESCRIPTION
## Summary
- Extracts the `refreshToken` from Twenty's `tokenPair` cookie alongside the access token
- When a GraphQL request gets a 401, calls Twenty's `renewToken` mutation to get a fresh access token and retries the request transparently
- Updates the in-memory token cache when a refresh succeeds so subsequent calls use the new token

## Test plan
- [ ] Corrupt the `accessOrWorkspaceAgnosticToken.token` in the `tokenPair` cookie via DevTools console
- [ ] Trigger an extension action (Test Connection or open a LinkedIn page)
- [ ] Confirm `[Twenty] Token renewed successfully` appears in the service worker console and the action succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)