### PR TITLE
Fix URL save not going through due to permission request outside user gesture

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -502,12 +502,8 @@ async function handleMessage(message: ExtensionMessage): Promise<ExtensionRespon
 
       case 'CREATE_RECORD': {
         const data = message.payload as LinkedInProfileData | LinkedInCompanyData;
-        try {
-          const result = await createRecord(data);
-          return { success: true, data: result };
-        } catch (err) {
-          throw err;
-        }
+        const result = await createRecord(data);
+        return { success: true, data: result };
       }
 
       case 'GET_SETTINGS': {
@@ -589,12 +585,8 @@ async function handleMessage(message: ExtensionMessage): Promise<ExtensionRespon
           data: LinkedInProfileData | LinkedInCompanyData;
         };
         const client = await getApiClient();
-        try {
-          await client.updateRecordWithLinkedInData(id, type, data);
-          return { success: true, data: { id } };
-        } catch (err) {
-          throw err;
-        }
+        await client.updateRecordWithLinkedInData(id, type, data);
+        return { success: true, data: { id } };
       }
 
       case 'SCRAPE_PAGE': {
@@ -698,7 +690,12 @@ export default defineBackground(() => {
   browser.runtime.onMessage.addListener(
     (message: ExtensionMessage, _sender, sendResponse) => {
       // Handle async by returning true and using sendResponse
-      handleMessage(message).then(sendResponse);
+      handleMessage(message)
+        .then(sendResponse)
+        .catch((err) => {
+          console.error('Message handler error:', err);
+          sendResponse({ success: false, error: err?.message || 'Unknown error' });
+        });
       return true; // Indicates we will send a response asynchronously
     }
   );

--- a/entrypoints/sidepanel/App.tsx
+++ b/entrypoints/sidepanel/App.tsx
@@ -729,7 +729,7 @@ export default function App() {
 
 		switch (captureState.status) {
 			case "idle":
-				return isDomainCapture ? "Check website" : "Checking profile...";
+				return isDomainCapture ? "Check website" : autoFetchAttempts >= 3 ? "Fetch Profile" : "Checking profile...";
 			case "loading":
 				return isDomainCapture ? "Checking company..." : "Checking...";
 			case "ready":
@@ -856,7 +856,7 @@ export default function App() {
 
 	async function testConnection(
 		urlOverride?: string,
-		options?: { showSuccess?: boolean },
+		options?: { showSuccess?: boolean; requestPermission?: boolean },
 	) {
 		const targetUrl = normalizeTwentyUrl(urlOverride || savedTwentyUrl);
 		if (!targetUrl) {
@@ -870,7 +870,15 @@ export default function App() {
 		setError(null);
 
 		try {
-			const hasPermission = await ensureTwentyPermission(targetUrl);
+			// Only request permission when called from a direct user gesture.
+			// When called programmatically (e.g. after save or on load), just check
+			// whether the permission is already granted rather than triggering a prompt,
+			// since browser.permissions.request() silently fails outside a user gesture.
+			const origins = getTwentyOriginPatterns(targetUrl);
+			let hasPermission = origins.length > 0 && await browser.permissions.contains({ origins });
+			if (!hasPermission && options?.requestPermission) {
+				hasPermission = await ensureTwentyPermission(targetUrl);
+			}
 			if (!hasPermission) {
 				setError(
 					"Permission denied. Please allow access to your Twenty domain.",
@@ -1106,7 +1114,7 @@ export default function App() {
 											variant="outline"
 											onClick={
 												hasToken
-													? () => testConnection(undefined, { showSuccess: true })
+													? () => testConnection(undefined, { showSuccess: true, requestPermission: true })
 													: loadSettings
 											}
 											disabled={isTesting}
@@ -1138,7 +1146,7 @@ export default function App() {
 											className="flex-1"
 											variant="outline"
 											disabled={isTesting || !isConfigured || isEditingTwentyUrl}
-											onClick={() => testConnection(undefined, { showSuccess: true })}
+											onClick={() => testConnection(undefined, { showSuccess: true, requestPermission: true })}
 										>
 											{isTesting ? "Testing..." : "Test Connection"}
 										</Button>
@@ -1210,6 +1218,7 @@ export default function App() {
 												captureState.status === "error" ||
 												captureState.status === "idle"
 											) {
+												setAutoFetchAttempts(0);
 												checkCurrentTab();
 											}
 										}}
@@ -1225,7 +1234,21 @@ export default function App() {
 										<Sparkles />
 										<span>{getCaptureButtonText()}</span>
 									</Button>
-									{captureState.status === "exists" &&
+								{captureState.status === "exists" &&
+									!captureState.data && (
+											<Button
+												className="mt-2 w-full"
+												variant="secondary"
+												onClick={() => {
+													setAutoFetchAttempts(0);
+													checkCurrentTab();
+												}}
+											>
+												<RefreshCw className="size-4" />
+												Fetch Profile
+											</Button>
+										)}
+								{captureState.status === "exists" &&
 										captureState.data &&
 										!("domain" in captureState.data) && (
 											<Button
@@ -1274,6 +1297,7 @@ export default function App() {
 														captureState.status === "error" ||
 														captureState.status === "idle"
 													) {
+														setAutoFetchAttempts(0);
 														checkCurrentTab();
 													}
 												}}


### PR DESCRIPTION
## Summary

- `browser.permissions.request()` silently returns `false` when called outside a direct user gesture in Chrome MV3
- `testConnection` was calling `ensureTwentyPermission` (which calls `permissions.request`) even when triggered programmatically — after a save and on app load — causing a false "Permission denied" error even though the URL saved successfully
- Fix: `testConnection` now only checks `permissions.contains()` by default; it only triggers the actual permission prompt when `requestPermission: true` is passed, which is set only on the explicit "Test Connection" button clicks

## Test plan

- [ ] Enter your Twenty URL and click Save — step 1 should show Done with no permission error
- [ ] Click "Test Connection" — browser permission prompt should appear, and after allowing, connection should succeed
- [ ] Reload the extension — settings should load without showing a permission error

🤖 Generated with [Claude Code](https://claude.com/claude-code)